### PR TITLE
Use a block with chdir, to restore original working directory

### DIFF
--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,7 +1,8 @@
 unless /mswin/ =~ RUBY_PLATFORM || RUBY_VERSION >= "1.9" || defined?(RUBY_ENGINE) && RUBY_ENGINE != "ruby"
   unless File.exists?(File.join(File.dirname(__FILE__), "..", "ext", "Makefile"))
-    Dir.chdir(File.join(File.dirname(__FILE__), "..", "ext"))
-    `rake`
+    Dir.chdir(File.join(File.dirname(__FILE__), "..", "ext")) do
+      `rake`
+    end
   end
 end
 


### PR DESCRIPTION
Use a block with chdir, as this will restore the original working directory after the command has been executed.

Should fix #16, but haven't tested as i am not using this project, debugging for an Engine Yard customer.
