### PR TITLE
primary_key_name is deprecated in Rails 3.1

### DIFF
--- a/lib/slim_scrooge/callsite.rb
+++ b/lib/slim_scrooge/callsite.rb
@@ -56,7 +56,7 @@ module SlimScrooge
     def essential_columns(model_class)
       model_class.reflect_on_all_associations.inject([@primary_key]) do |arr, assoc|
         if assoc.options[:dependent] && assoc.macro == :belongs_to
-          arr << assoc.primary_key_name
+          arr << assoc.respond_to?(:foreign_key) ? assoc.foreign_key : assoc.primary_key_name
         end
         arr
       end


### PR DESCRIPTION
just want to report that primary_key_name. sorry, iam not able right now to provide a patch. i think its in

<pre><code>DEPRECATION WARNING: primary_key_name is deprecated and will be removed from Rails 3.2 (use foreign_key instead).
</code></pre>
